### PR TITLE
プロジェクト設定：ドキュメントフォルダに.nojekyllを追加

### DIFF
--- a/.github/workflows/build-vue.yml
+++ b/.github/workflows/build-vue.yml
@@ -39,6 +39,9 @@ jobs:
           mkdir ./docs
           mv ./dist/* ./docs/
 
+      - name: add .nojekyll
+        run: touch ./docs/.nojekyll
+
       - name: Commit and push
         run: |
           git config user.name "GitHub Action"


### PR DESCRIPTION
https://qiita.com/ozaki25/items/fe9912fc41c3a5c5bfea

上記記事より、引用

## はまりどころ②JSファイルが404になってしまう問題

- ここまでの手順でデプロイに成功し画面を表示することはできますが、JSファイルなどの取得が全て404になってしまいます
    - URLは正しいはずなのになぜ？？？とはまりました

- 原因はGitHub Pagesの仕様として`_`から始まるディレクトリが見えないというものでした
    - 404が出てるファイルは`_next`以下に配置されている
- 回避するためには`.nojekyll`というファイルをデプロイ対象のディレクトリに配置する必要があります
- GitHub Actionsの設定ファイルのexportの後に`touch out/.nojekyll`を追加します